### PR TITLE
Add element at index 0 of quest list

### DIFF
--- a/cosmosDefines.h
+++ b/cosmosDefines.h
@@ -126,6 +126,7 @@ static map<string, int> rarities { // hero rarities
 };
 
 static vector<vector<string>> quests { // Contains all quest lineups for easy referencing
+	{""},
 	{"w5"},
 	{"f1", "a1", "f1", "a1", "f1", "a1"},
 	{"f5", "a5"},


### PR DESCRIPTION
Given that most users won't know that arrays are 0-indexed, adding an additional empty element at the start of the array will allow users to map quests[n] to the quest number n instead of quest n+1. 